### PR TITLE
Changes conversation listener

### DIFF
--- a/lib/Dialog.js
+++ b/lib/Dialog.js
@@ -63,6 +63,10 @@ var Dialog = function Dialog(originalMessage, timeoutValue, timeoutMessage) {
         var text = msg.message.text,
             matched = false;
 
+        if (!text) {
+            return;
+        }
+
         //Stop at the first match in the order in which they were added.
         debug('Receiving message', choices);
         matched = choices.some(function (choice) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,21 +11,29 @@ module.exports = function Conversation(bot, type) {
     type = type || 'user';
 
     var getId = function(msg) {
+        msg = msg.user ? msg : msg.message;
         return (type === 'user')? msg.user.id : msg.room;
     };
 
-    //Register a custom listener that will spy on all incoming messages
-    bot.listen(
-        function matcher(msg) {
+    function spy(msg) {
+        var id = getId(msg);
+        debug('Accepting message for ', id);
+        _talkingTo[id].receive(msg);
+    }
+
+    //Register a listener that will spy on all received messages
+    bot.receiveMiddleware(
+        function matcher(context, next, done) {
+            var msg = context.response;
             var id = getId(msg);
             //If a dialog is currently open with this user, accept the message.
             debug('Checking if talking to   ' + id + ' = ' + !!_talkingTo[id]);
-            return _talkingTo[id];
-        },
-        function spy(msg) {
-            var id = getId(msg.message);
-            debug('Accepting message for ', id);
-            _talkingTo[id].receive(msg);
+
+            if (_talkingTo[id]) {
+                spy(msg);
+            }
+
+            next(done);
         }
     );
 


### PR DESCRIPTION
Changes the `hubot-conversation` listener to `receiveMiddleware`.

Using `listen`, we couldn't stop the message propagation (`msg.finish()`) because it runs after the scripts matches (flow). If the user starts a dialog and the bot expects an yes/no option, the user could answer with another command and the bot will accept it.

Changing to `receiveMiddleware`, it runs before the matches and we can stop the message propagation (`msg.finish()`). 
